### PR TITLE
feat: GRPC supports query's height param

### DIFF
--- a/bin/v0.34.x/rpc/register.go
+++ b/bin/v0.34.x/rpc/register.go
@@ -90,10 +90,13 @@ func StartRPC(
 	// caching middleware
 	apiSrv.Router.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-			height, err := strconv.ParseInt(request.URL.Query().Get("height"), 10, 64)
+			heightQuery := request.URL.Query().Get("height")
+			height, err := strconv.ParseInt(heightQuery, 10, 64)
 
 			// don't use archival cache if height is 0 or error
 			if err == nil && height > 0 {
+				// GRPC query parses height from header
+				request.Header.Add("x-cosmos-block-height", heightQuery)
 				archivalCache.HandleCachedHTTP(writer, request, next)
 			} else {
 				cache.HandleCachedHTTP(writer, request, next)


### PR DESCRIPTION
- GRPC gateway parses query's height parameter from the `x-cosmos-block-height` rather than URL.
- setting height into request header before parsing would be an workaround.