### PR TITLE
Upgrade tm-db to v0.6.4-performance.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,14 +107,11 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-replace github.com/cosmos/ledger-cosmos-go => github.com/terra-money/ledger-terra-go v0.11.2
-
-replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
-
-replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-
-replace github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-
-replace github.com/CosmWasm/wasmvm => github.com/terra-money/wasmvm v0.16.4
-
-replace github.com/tendermint/tm-db => github.com/terra-money/tm-db v0.6.5-0.20220307182415-c71e8b6e9f20
+replace (
+	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
+	github.com/CosmWasm/wasmvm => github.com/terra-money/wasmvm v0.16.4
+	github.com/cosmos/ledger-cosmos-go => github.com/terra-money/ledger-terra-go v0.11.2
+	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+	github.com/tendermint/tm-db => github.com/terra-money/tm-db v0.6.4-performance.7
+	google.golang.org/grpc => google.golang.org/grpc v1.33.2
+)

--- a/go.sum
+++ b/go.sum
@@ -775,8 +775,8 @@ github.com/terra-money/core v0.5.18-0.20220304040324-70c1ef6f11b0 h1:40hUUCkXo31
 github.com/terra-money/core v0.5.18-0.20220304040324-70c1ef6f11b0/go.mod h1:aUZfcVV4GP92baeM/XLFN3FOWzkMUrLjMs3B1+MDovY=
 github.com/terra-money/ledger-terra-go v0.11.2 h1:BVXZl+OhJOri6vFNjjVaTabRLApw9MuG7mxWL4V718c=
 github.com/terra-money/ledger-terra-go v0.11.2/go.mod h1:ClJ2XMj1ptcnONzKH+GhVPi7Y8pXIT+UzJ0TNt0tfZE=
-github.com/terra-money/tm-db v0.6.5-0.20220307182415-c71e8b6e9f20 h1:SRTmFwbfR2+uirbUxwXqSbKMCFOCD8rUxtpCqNomCC4=
-github.com/terra-money/tm-db v0.6.5-0.20220307182415-c71e8b6e9f20/go.mod h1:K6twQf1PGDxC6K6V+G2l0nrYsQAxsypb4PpbJnyzwJw=
+github.com/terra-money/tm-db v0.6.4-performance.7 h1:eS7qNoUf+a0A0nWRieFg1iNneBaf80TMkShPLE8onnM=
+github.com/terra-money/tm-db v0.6.4-performance.7/go.mod h1:K6twQf1PGDxC6K6V+G2l0nrYsQAxsypb4PpbJnyzwJw=
 github.com/terra-money/wasmvm v0.16.4 h1:7zPlIV9zFy4NH+kfV2Yu9o5pMuD6rK36Fmdw4/CLur0=
 github.com/terra-money/wasmvm v0.16.4/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=


### PR DESCRIPTION
## Description
This PR changes tm-db to `v0.6.4-performance.7` forked from the official [tm-db](https://github.com/tendermint/tm-db) and with several performance upgrades

1. Tune goleveldb configuration (1GiB BlockCache, 64MiB WriteBuffer, BloomFilter and disable seeks compaction)
2. Remove redundant mutex from PrefixDB
3. Remove redundant error and assertion check in the iterator which causes significant performance degrades
4. Tune RocksDB configuration