### PR TITLE
Bump CosmWasm to 0.16.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 .vscode
 .DS_Store
+build
 **/*.no-commit.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,13 @@ WORKDIR /code
 COPY . /code/
 
 # See https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/terra-money/wasmvm/releases/download/v0.16.4/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
+ADD https://github.com/cosmwasm/wasmvm/releases/download/v0.16.6/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.a
 
 # use mimalloc for musl
 RUN git clone --depth 1 https://github.com/microsoft/mimalloc; cd mimalloc; mkdir build; cd build; cmake ..; make -j$(nproc); make install
 
-ENV MIMALLOC_RESERVE_HUGE_OS_PAGES=4
-
 # force it to use static lib (from above) not standard libgo_cosmwasm.so file
-RUN LEDGER_ENABLED=false go build -work -tags muslc,linux -mod=readonly -ldflags="-extldflags '-L/code/mimalloc/build -lmimalloc'" -o build/mantlemint ./sync.go
+RUN LEDGER_ENABLED=false go build -work -tags muslc,linux -mod=readonly -ldflags="-extldflags '-L/code/mimalloc/build -lmimalloc -static'" -o build/mantlemint ./sync.go
 
 FROM alpine:3.12
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ Please note that mantlemint still is able to serve queries while `/health` retur
 - Replaces ABCIClient with [NewConcurrentQueryClient](https://github.com/terra-money/mantlemint/blob/main/mantlemint/client.go#L110): Removal of mutexes allow better concurrency, even during block injection
 - Uses single batch-protected db: All state changes are flushed at once, making it safe to read from db during block injection
 - Automatic failover: In case of block injection failure, mantlemint reverts back to the previous known state and retry
+- Strictly no `tendermint`; some parameters in app.toml would not affect `mantlemint`
+- Following endpoints are  not implemented
+  - `GET /blocks/`
+  - `GET /blocks/latest`
+  - `GET /txs/{hash}`
+  - `GET /txs`
+  - `GET /validatorset`
+  - All `POST` variants
 
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -132,9 +132,6 @@ Please note that mantlemint still is able to serve queries while `/health` retur
 - [Twitter](https://twitter.com/terra_money)
 - [YouTube](https://goo.gl/3G4T1z)
 
-## Contributing
-
-If you are interested in contributing to Terra Core source, please review our [code of conduct](./CODE_OF_CONDUCT.md).
 
 # License
 

--- a/go.mod
+++ b/go.mod
@@ -16,14 +16,14 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/tendermint v0.34.14
 	github.com/tendermint/tm-db v0.6.6
-	github.com/terra-money/core v0.5.18-0.20220304040324-70c1ef6f11b0
+	github.com/terra-money/core v0.5.17
 )
 
 require (
 	filippo.io/edwards25519 v1.0.0-beta.2 // indirect
 	github.com/99designs/keyring v1.1.6 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
-	github.com/CosmWasm/wasmvm v0.16.3 // indirect
+	github.com/CosmWasm/wasmvm v0.16.5 // indirect
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/armon/go-metrics v0.3.9 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -111,10 +111,10 @@ replace github.com/cosmos/ledger-cosmos-go => github.com/terra-money/ledger-terr
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
+replace github.com/CosmWasm/wasmvm => github.com/terra-money/wasmvm v0.16.6
+
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
 replace github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-
-replace github.com/CosmWasm/wasmvm => github.com/terra-money/wasmvm v0.16.4
 
 replace github.com/tendermint/tm-db => github.com/terra-money/tm-db v0.6.5-0.20220307182415-c71e8b6e9f20

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	filippo.io/edwards25519 v1.0.0-beta.2 // indirect
 	github.com/99designs/keyring v1.1.6 // indirect
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
-	github.com/CosmWasm/wasmvm v0.16.5 // indirect
+	github.com/CosmWasm/wasmvm v0.16.6 // indirect
 	github.com/DataDog/zstd v1.4.5 // indirect
 	github.com/armon/go-metrics v0.3.9 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -109,7 +109,6 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-	github.com/CosmWasm/wasmvm => github.com/terra-money/wasmvm v0.16.6
 	github.com/cosmos/ledger-cosmos-go => github.com/terra-money/ledger-terra-go v0.11.2
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tm-db => github.com/terra-money/tm-db v0.6.4-performance.7

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,9 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
+github.com/CosmWasm/wasmvm v0.16.3/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
+github.com/CosmWasm/wasmvm v0.16.6 h1:YEqno8DJifj+1NixXSJGOXCKGX4Qb4kdYK1+JIHLpog=
+github.com/CosmWasm/wasmvm v0.16.6/go.mod h1:saGLYYSj6rRVFL6EaWZHzXbLD3Rgn8ZEK+0H+UjKOE4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
@@ -778,8 +781,6 @@ github.com/terra-money/ledger-terra-go v0.11.2 h1:BVXZl+OhJOri6vFNjjVaTabRLApw9M
 github.com/terra-money/ledger-terra-go v0.11.2/go.mod h1:ClJ2XMj1ptcnONzKH+GhVPi7Y8pXIT+UzJ0TNt0tfZE=
 github.com/terra-money/tm-db v0.6.4-performance.7 h1:eS7qNoUf+a0A0nWRieFg1iNneBaf80TMkShPLE8onnM=
 github.com/terra-money/tm-db v0.6.4-performance.7/go.mod h1:K6twQf1PGDxC6K6V+G2l0nrYsQAxsypb4PpbJnyzwJw=
-github.com/terra-money/wasmvm v0.16.6 h1:kFk+O4e6hLVsICJ5FGsMurT5gjJJoqrDr0R2DoMY8E4=
-github.com/terra-money/wasmvm v0.16.6/go.mod h1:saGLYYSj6rRVFL6EaWZHzXbLD3Rgn8ZEK+0H+UjKOE4=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/go.sum
+++ b/go.sum
@@ -759,6 +759,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
@@ -771,14 +772,14 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/tendermint v0.34.14 h1:GCXmlS8Bqd2Ix3TQCpwYLUNHe+Y+QyJsm5YE+S/FkPo=
 github.com/tendermint/tendermint v0.34.14/go.mod h1:FrwVm3TvsVicI9Z7FlucHV6Znfd5KBc/Lpp69cCwtk0=
-github.com/terra-money/core v0.5.18-0.20220304040324-70c1ef6f11b0 h1:40hUUCkXo31cSh9QsVzTj2BrDUoawKVIytzcPqcJNvQ=
-github.com/terra-money/core v0.5.18-0.20220304040324-70c1ef6f11b0/go.mod h1:aUZfcVV4GP92baeM/XLFN3FOWzkMUrLjMs3B1+MDovY=
+github.com/terra-money/core v0.5.17 h1:LyQKVLEawSqn+AV+BcslP9H6qFUvFJxDBHzjvm3yl+Q=
+github.com/terra-money/core v0.5.17/go.mod h1:MEpq9DsEr2lBs8P7GiIJLfBqCZZKHfdl5qEs0nOcQkg=
 github.com/terra-money/ledger-terra-go v0.11.2 h1:BVXZl+OhJOri6vFNjjVaTabRLApw9MuG7mxWL4V718c=
 github.com/terra-money/ledger-terra-go v0.11.2/go.mod h1:ClJ2XMj1ptcnONzKH+GhVPi7Y8pXIT+UzJ0TNt0tfZE=
 github.com/terra-money/tm-db v0.6.5-0.20220307182415-c71e8b6e9f20 h1:SRTmFwbfR2+uirbUxwXqSbKMCFOCD8rUxtpCqNomCC4=
 github.com/terra-money/tm-db v0.6.5-0.20220307182415-c71e8b6e9f20/go.mod h1:K6twQf1PGDxC6K6V+G2l0nrYsQAxsypb4PpbJnyzwJw=
-github.com/terra-money/wasmvm v0.16.4 h1:7zPlIV9zFy4NH+kfV2Yu9o5pMuD6rK36Fmdw4/CLur0=
-github.com/terra-money/wasmvm v0.16.4/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
+github.com/terra-money/wasmvm v0.16.6 h1:kFk+O4e6hLVsICJ5FGsMurT5gjJJoqrDr0R2DoMY8E4=
+github.com/terra-money/wasmvm v0.16.6/go.mod h1:saGLYYSj6rRVFL6EaWZHzXbLD3Rgn8ZEK+0H+UjKOE4=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
## Description
This PR upgrades CosmWasm to 0.16.6 which requires cache rebuild. manual cache rebuilder is available at https://github.com/YunSuk-Yeo/wasm-cache-rebuilder