### PR TITLE
feat: added indexer for proposal votes and transactions

### DIFF
--- a/db/snappy/snappy_db.go
+++ b/db/snappy/snappy_db.go
@@ -90,12 +90,20 @@ func (s *SnappyDB) DeleteSync(key []byte) error {
 	return s.Delete(key)
 }
 
-func (s *SnappyDB) Iterator(start, end []byte) (tmdb.Iterator, error) {
-	return nil, errIteratorNotSupported
+func (s *SnappyDB) Iterator(start, end []byte) (iter tmdb.Iterator, err error) {
+	iter, err = s.db.Iterator(start, end)
+	if err != nil {
+		return iter, err
+	}
+	return NewSnappyIterator(iter, s.compatMode), nil
 }
 
-func (s *SnappyDB) ReverseIterator(start, end []byte) (tmdb.Iterator, error) {
-	return nil, errIteratorNotSupported
+func (s *SnappyDB) ReverseIterator(start, end []byte) (iter tmdb.Iterator, err error) {
+	iter, err = s.db.ReverseIterator(start, end)
+	if err != nil {
+		return iter, err
+	}
+	return NewSnappyIterator(iter, s.compatMode), nil
 }
 
 func (s *SnappyDB) Close() error {

--- a/db/snappy/snappy_db_iterator.go
+++ b/db/snappy/snappy_db_iterator.go
@@ -1,0 +1,61 @@
+package snappy
+
+import (
+	"github.com/golang/snappy"
+	tmdb "github.com/tendermint/tm-db"
+)
+
+type SnappyIterator struct {
+	iter       tmdb.Iterator
+	compatMode int
+	err        error
+}
+
+var (
+	_ tmdb.Iterator = SnappyIterator{}
+)
+
+func NewSnappyIterator(iter tmdb.Iterator, compactMode int) SnappyIterator {
+	return SnappyIterator{
+		iter:       iter,
+		compatMode: compactMode,
+		err:        nil,
+	}
+}
+
+func (s SnappyIterator) Domain() (start []byte, end []byte) {
+	return s.iter.Domain()
+}
+
+func (s SnappyIterator) Valid() bool {
+	return s.iter.Valid()
+}
+
+func (s SnappyIterator) Next() {
+	s.iter.Next()
+}
+
+func (s SnappyIterator) Key() (key []byte) {
+	return s.iter.Key()
+}
+
+func (s SnappyIterator) Value() (value []byte) {
+	val := s.iter.Value()
+	if val == nil {
+		return nil
+	}
+	decoded, decodeErr := snappy.Decode(nil, val)
+	s.err = decodeErr
+	return decoded
+}
+
+func (s SnappyIterator) Error() error {
+	if s.err != nil {
+		return s.err
+	}
+	return s.iter.Error()
+}
+
+func (s SnappyIterator) Close() error {
+	return s.iter.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/tendermint/tendermint v0.34.23
 	github.com/tendermint/tm-db v0.6.7
 	github.com/terra-money/alliance v0.0.1-wasm.1
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 )
 
 require (
@@ -186,7 +187,6 @@ require (
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
-	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/oauth2 v0.2.0 // indirect

--- a/indexer/accounttx/accounttx.go
+++ b/indexer/accounttx/accounttx.go
@@ -1,0 +1,145 @@
+package accounttx
+
+import (
+	"encoding/json"
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ignite/cli/ignite/pkg/cosmoscmd"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tm "github.com/tendermint/tendermint/types"
+	terra "github.com/terra-money/alliance/app"
+	"github.com/terra-money/mantlemint/db/safe_batch"
+	"github.com/terra-money/mantlemint/indexer"
+	"github.com/terra-money/mantlemint/mantlemint"
+)
+
+var cdc = cosmoscmd.MakeEncodingConfig(terra.ModuleBasics)
+
+var IndexTx = indexer.CreateIndexer(func(db safe_batch.SafeBatchDB, block *tm.Block, blockID *tm.BlockID, evc *mantlemint.EventCollector, _ *cosmoscmd.App) error {
+	for i, txByte := range block.Txs {
+		txRecord := evc.ResponseDeliverTxs[i]
+		addrsInTx, err := parseTxBytesForAddresses(txByte)
+		if err != nil {
+			return err
+		}
+		addrsInEvents, err := parseEventsForAddresses(txRecord.Events)
+		if err != nil {
+			return err
+		}
+
+		for k, _ := range addrsInEvents {
+			addrsInTx[k] = true
+		}
+
+		for addr, _ := range addrsInTx {
+			key := GetAccountTxKey(addr, uint64(block.Height), uint64(i))
+			accountTx := AccountTx{
+				TxHash: fmt.Sprintf("%X", txByte.Hash()),
+			}
+			b, err := json.Marshal(accountTx)
+			if err != nil {
+				return err
+			}
+			err = db.Set(key, b)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+})
+
+func parseTxBytesForAddresses(txByte []byte) (addrs map[string]bool, err error) {
+	// Use a map to collect unique addresses
+	addrs = make(map[string]bool)
+
+	// Decode to Tx struct
+	tx, err := cdc.TxConfig.TxDecoder()(txByte)
+	if err != nil {
+		return addrs, err
+	}
+
+	wrappedTx, err := cdc.TxConfig.WrapTxBuilder(tx)
+	if err != nil {
+		return addrs, err
+	}
+
+	signers := wrappedTx.GetTx().GetSigners()
+	for _, signer := range signers {
+		addr, err := sdk.Bech32ifyAddressBytes(terra.AccountAddressPrefix, signer)
+		if err != nil {
+			return addrs, err
+		}
+		addrs[addr] = true
+	}
+
+	// Encode to JSON
+	jsonByte, err := cdc.TxConfig.TxJSONEncoder()(tx)
+	if err != nil {
+		return addrs, err
+	}
+	// Decode to generic interface to find addresses
+	var txRaw map[string]interface{}
+	err = json.Unmarshal(jsonByte, &txRaw)
+	if err != nil {
+		return addrs, err
+	}
+	bodyRaw, found := txRaw["body"]
+	if !found {
+		return addrs, nil
+	}
+
+	body, ok := bodyRaw.(map[string]interface{})
+	if !ok {
+		return addrs, fmt.Errorf("unable to coerce tx body into map")
+	}
+
+	var findAddresses func(o interface{})
+	findAddresses = func(o interface{}) {
+		stringValue, isString := o.(string)
+		if isString {
+			_, err := sdk.GetFromBech32(stringValue, terra.AccountAddressPrefix)
+			if err == nil {
+				addrs[stringValue] = true
+			}
+			return
+		}
+
+		mapValue, isMap := o.(map[string]interface{})
+		if isMap {
+			for _, v := range mapValue {
+				findAddresses(v)
+			}
+			return
+		}
+
+		arrayValue, isArray := o.([]interface{})
+		if isArray {
+			for _, a := range arrayValue {
+				findAddresses(a)
+			}
+		}
+	}
+
+	msgsRaw, found := body["messages"]
+	if !found {
+		return addrs, nil
+	}
+	findAddresses(msgsRaw)
+	return addrs, nil
+}
+
+func parseEventsForAddresses(events []abci.Event) (addrs map[string]bool, err error) {
+	addrs = make(map[string]bool)
+	for _, event := range events {
+		attrs := event.GetAttributes()
+		for _, attr := range attrs {
+			addrStr := string(attr.GetValue())
+			_, err := sdk.GetFromBech32(addrStr, terra.AccountAddressPrefix)
+			if err == nil {
+				addrs[addrStr] = true
+			}
+		}
+	}
+	return addrs, nil
+}

--- a/indexer/accounttx/client.go
+++ b/indexer/accounttx/client.go
@@ -1,0 +1,51 @@
+package accounttx
+
+import (
+	"github.com/gorilla/mux"
+	tmjson "github.com/tendermint/tendermint/libs/json"
+	tmdb "github.com/tendermint/tm-db"
+	"github.com/terra-money/mantlemint/indexer"
+	"net/http"
+	"strconv"
+)
+
+var (
+	defaultLimit          = uint64(100)
+	defaultOffset         = uint64(0)
+	EndpointGETAccountTxs = "/index/account/{account}"
+)
+
+var RegisterRESTRoute = indexer.CreateRESTRoute(func(router *mux.Router, indexerDB tmdb.DB) {
+	router.HandleFunc(EndpointGETAccountTxs, func(w http.ResponseWriter, r *http.Request) {
+		account, ok := mux.Vars(r)["account"]
+		if !ok {
+			http.Error(w, "invalid request: account not found", 400)
+			return
+		}
+		queries := r.URL.Query()
+		offset, err := strconv.ParseUint(queries.Get("offset"), 10, 64)
+		if err != nil {
+			offset = defaultOffset
+		}
+		limit, err := strconv.ParseUint(queries.Get("offset"), 10, 64)
+		if err != nil {
+			limit = defaultLimit
+		}
+		txs, err := getTxnsByAccount(indexerDB, account, offset, limit)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+		}
+
+		rxRes := &GetAccountTxsResponse{
+			Limit:  limit,
+			Offset: offset,
+			Txs:    txs,
+		}
+		res, err := tmjson.Marshal(rxRes)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+		}
+		w.WriteHeader(200)
+		w.Write(res)
+	})
+})

--- a/indexer/accounttx/types.go
+++ b/indexer/accounttx/types.go
@@ -1,6 +1,9 @@
 package accounttx
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	"encoding/json"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 type AccountTx struct {
 	TxHash string `json:"txhash"`
@@ -19,4 +22,10 @@ func GetAccountTxKey(addr string, blockHeight uint64, txIndex uint64) (key []byt
 	key = append(GetAccountTxKeyByAddr(addr), sdk.Uint64ToBigEndian(blockHeight)...)
 	key = append(key, sdk.Uint64ToBigEndian(txIndex)...)
 	return key
+}
+
+type GetAccountTxsResponse struct {
+	Limit  uint64            `json:"limit"`
+	Offset uint64            `json:"offset"`
+	Txs    []json.RawMessage `json:"txs"`
 }

--- a/indexer/accounttx/types.go
+++ b/indexer/accounttx/types.go
@@ -1,0 +1,22 @@
+package accounttx
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+type AccountTx struct {
+	TxHash string `json:"txhash"`
+}
+
+var (
+	AccountTxPrefix = []byte("account_tx/address:")
+)
+
+func GetAccountTxKeyByAddr(addr string) (key []byte) {
+	key = append(AccountTxPrefix, addr...)
+	return key
+}
+
+func GetAccountTxKey(addr string, blockHeight uint64, txIndex uint64) (key []byte) {
+	key = append(GetAccountTxKeyByAddr(addr), sdk.Uint64ToBigEndian(blockHeight)...)
+	key = append(key, sdk.Uint64ToBigEndian(txIndex)...)
+	return key
+}

--- a/indexer/accounttx/types.go
+++ b/indexer/accounttx/types.go
@@ -1,12 +1,15 @@
 package accounttx
 
 import (
-	"encoding/json"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/terra-money/mantlemint/indexer/tx"
+	"time"
 )
 
 type AccountTx struct {
-	TxHash string `json:"txhash"`
+	TxHash      string    `json:"txhash"`
+	BlockHeight uint64    `json:"height"`
+	Timestamp   time.Time `json:"timestamp"`
 }
 
 var (
@@ -25,7 +28,7 @@ func GetAccountTxKey(addr string, blockHeight uint64, txIndex uint64) (key []byt
 }
 
 type GetAccountTxsResponse struct {
-	Limit  uint64            `json:"limit"`
-	Offset uint64            `json:"offset"`
-	Txs    []json.RawMessage `json:"txs"`
+	Limit  uint64                `json:"limit"`
+	Offset uint64                `json:"offset"`
+	Txs    []tx.TxByHeightRecord `json:"txs"`
 }

--- a/indexer/block/block.go
+++ b/indexer/block/block.go
@@ -25,3 +25,24 @@ var IndexBlock = indexer.CreateIndexer(func(indexerDB safe_batch.SafeBatchDB, bl
 
 	return indexerDB.Set(getKey(uint64(block.Height)), recordJSON)
 })
+
+func IterateBlocks(indexerDb safe_batch.SafeBatchDB, start int64, end int64, cb func(block *tm.Block) (stop bool)) (err error) {
+	iter, err := indexerDb.Iterator(getKey(uint64(start)), getKey(uint64(end)))
+	if err != nil {
+		return err
+	}
+	for iter.Valid() {
+		b := iter.Value()
+		var block BlockRecord
+		err := tmjson.Unmarshal(b, &block)
+		if err != nil {
+			return err
+		}
+		stop := cb(block.Block)
+		if stop {
+			return nil
+		}
+		iter.Next()
+	}
+	return nil
+}

--- a/indexer/proposal/client.go
+++ b/indexer/proposal/client.go
@@ -1,0 +1,58 @@
+package proposal
+
+import (
+	"fmt"
+	"github.com/gorilla/mux"
+	tmjson "github.com/tendermint/tendermint/libs/json"
+	tmdb "github.com/tendermint/tm-db"
+	"github.com/terra-money/mantlemint/indexer"
+	"net/http"
+	"strconv"
+)
+
+var (
+	EndpointGETProposal = "/index/proposal/{id}"
+)
+
+var (
+	ErrorProposalId       = func(id string) string { return fmt.Sprintf("invalid proposal id %s", id) }
+	ErrorRichlistNotFound = func(height string) string { return fmt.Sprintf("richlist at %s not found... yet.", height) }
+	EmptyVotes            = []Vote{}
+)
+
+var RegisterRESTRoute = indexer.CreateRESTRoute(func(router *mux.Router, db tmdb.DB) {
+	router.HandleFunc(EndpointGETProposal, func(writer http.ResponseWriter, request *http.Request) {
+		vars := mux.Vars(request)
+		proposalIdStr, ok := vars["id"]
+		if !ok {
+			http.Error(writer, ErrorProposalId(proposalIdStr), 400)
+			return
+		}
+
+		proposalId, err := strconv.ParseUint(proposalIdStr, 10, 64)
+		if err != nil {
+			http.Error(writer, ErrorProposalId(proposalIdStr), 400)
+			return
+		}
+		proposal, err := GetProposal(db, proposalId)
+		if err != nil {
+			// instead of returning error, we follow api service and return empty array
+			res, err := tmjson.Marshal(EmptyVotes)
+			if err != nil {
+				http.Error(writer, err.Error(), 500)
+				return
+			}
+			writer.WriteHeader(200)
+			writer.Write(res)
+			return
+		}
+
+		res, err := tmjson.Marshal(proposal.Votes)
+		if err != nil {
+			http.Error(writer, err.Error(), 500)
+			return
+		}
+		writer.WriteHeader(200)
+		writer.Write(res)
+	})
+})

--- a/indexer/proposal/indexer.go
+++ b/indexer/proposal/indexer.go
@@ -1,0 +1,396 @@
+package proposal
+
+import (
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	govtypesv1b1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	"github.com/ignite/cli/ignite/pkg/cosmoscmd"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmjson "github.com/tendermint/tendermint/libs/json"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/proto/tendermint/types"
+	tm "github.com/tendermint/tendermint/types"
+	tmdb "github.com/tendermint/tm-db"
+	tapp "github.com/terra-money/alliance/app"
+	"github.com/terra-money/mantlemint/db/safe_batch"
+	"github.com/terra-money/mantlemint/indexer"
+	blockindexer "github.com/terra-money/mantlemint/indexer/block"
+	txindexer "github.com/terra-money/mantlemint/indexer/tx"
+	"github.com/terra-money/mantlemint/mantlemint"
+	"golang.org/x/exp/maps"
+	"os"
+	"strconv"
+)
+
+var IndexProposals = indexer.CreateIndexer(proposalIndexerFunc)
+var cdc = cosmoscmd.MakeEncodingConfig(tapp.ModuleBasics)
+var logger log.Logger
+
+func init() {
+	govtypesv1.RegisterInterfaces(cdc.InterfaceRegistry)
+	logger = log.NewTMLogger(os.Stdout)
+}
+
+func proposalIndexerFunc(db safe_batch.SafeBatchDB, block *tm.Block, blockID *tm.BlockID, evc *mantlemint.EventCollector, app *cosmoscmd.App) (err error) {
+	lastHeight, err := getLastIndexedHeight(db)
+	fmt.Printf("[indexer/proposals] last height: %d current height %d\n", lastHeight, block.Height)
+	if err != nil {
+		return err
+	}
+
+	// if last indexed height is not the last block, perform historical indexing by replaying old blocks
+	if block.Height-lastHeight != 1 {
+		err = indexHistoricalProposals(db, app, lastHeight, block.Height)
+	} else {
+		err = indexNewBlock(db, app, evc, block)
+	}
+	if err != nil {
+		panic(err)
+	}
+
+	err = db.Set(lastIndexedHeightKey, sdk.Uint64ToBigEndian(uint64(block.Height)))
+	if err != nil {
+		return err
+	}
+
+	count := 0
+	IterateProposals(db, 0, func(proposal Proposal) bool {
+		count += 1
+		return false
+	})
+	fmt.Printf("[indexer/proposals] indexed %d proposals\n", count)
+	return nil
+}
+
+func indexHistoricalProposals(db safe_batch.SafeBatchDB, app *cosmoscmd.App, lastHeight int64, currentHeight int64) (err error) {
+	fmt.Printf("[indexer/proposals] indexing historical from %d\n", lastHeight)
+	var proposalsAdded []*Proposal
+
+	// Go through all blocks
+	err = blockindexer.IterateBlocks(db, lastHeight, currentHeight, func(block *tm.Block) bool {
+		fmt.Println("[indexer/proposals] block", block.Height, "has", len(block.Txs), "txs")
+		fmt.Println("[indexer/proposals] processing block", block.Height)
+		// For each block, get all transactions to look for proposal creation txns
+		for _, txByte := range block.Txs {
+			hash := fmt.Sprintf("%X", txByte.Hash())
+			var txRecord txindexer.TxRecord
+			var txResponse txindexer.ResponseDeliverTx
+			txRecord, err = txindexer.GetTxByHash(db, hash)
+			if err != nil {
+				return true
+			}
+			err = tmjson.Unmarshal(txRecord.TxResponse, &txResponse)
+			if err != nil {
+				return true
+			}
+			for _, event := range txResponse.Events {
+				switch event.Type {
+				case govtypes.EventTypeProposalDeposit, govtypes.EventTypeSubmitProposal:
+					proposalIdStr, found := findAttributeValue(event.Attributes, govtypes.AttributeKeyVotingPeriodStart)
+					var proposalId uint64
+					if found {
+						proposalId, err = strconv.ParseUint(proposalIdStr, 10, 64)
+						if err != nil {
+							return true
+						}
+						proposal := NewProposal(proposalId, govtypesv1.ProposalStatus_PROPOSAL_STATUS_VOTING_PERIOD)
+						proposalsAdded = append(proposalsAdded, &proposal)
+					}
+				}
+			}
+		}
+		if err != nil {
+			panic(err)
+		}
+
+		// Find all non-completed proposals and get current voter counts
+		for _, proposal := range proposalsAdded {
+			fmt.Println("[indexer/proposals] Processing proposal", proposal.Id)
+			if proposal.Status == govtypesv1.ProposalStatus_PROPOSAL_STATUS_VOTING_PERIOD {
+				appProposal, err := getProposalFromApp(block.Height, app, proposal.Id)
+				if err != nil {
+					panic(err)
+				}
+				if appProposal.Status != govtypesv1.ProposalStatus_PROPOSAL_STATUS_VOTING_PERIOD {
+					proposal.Status = appProposal.Status
+				} else {
+					var votes []Vote
+					votes, err = getVoters(block.Height, app, proposal.Id)
+					if err != nil {
+						panic(err)
+					}
+					proposal.Votes = votes
+				}
+			}
+		}
+		return false
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Update all new proposals
+	for _, proposal := range proposalsAdded {
+		err = upsertProposal(db, proposal.Id, *proposal)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func indexNewBlock(db safe_batch.SafeBatchDB, app *cosmoscmd.App, evc *mantlemint.EventCollector, block *tm.Block) (err error) {
+	proposalsToUpdate := make(map[uint64]*Proposal)
+	// parse tx events for proposal creation or deposit messages
+	// then find vote messages
+	for i, txByte := range block.Txs {
+		txResponse := evc.ResponseDeliverTxs[i]
+		if txResponse.IsErr() {
+			continue
+		}
+
+		tx, err := cdc.TxConfig.TxDecoder()(txByte)
+		if err != nil {
+			return err
+		}
+
+		for _, msg := range tx.GetMsgs() {
+			_, isMsgSubmitProposal := msg.(*govtypesv1b1.MsgSubmitProposal)
+			if isMsgSubmitProposal {
+				for _, event := range txResponse.Events {
+					switch event.Type {
+					case govtypes.EventTypeSubmitProposal:
+						proposalIdStr, found := findAbciAttributeValue(event.Attributes, govtypes.AttributeKeyProposalID)
+						var proposalId uint64
+						if found {
+							proposalId, err = strconv.ParseUint(proposalIdStr, 10, 64)
+							if err != nil {
+								return err
+							}
+							// proposal status here doesn't really matter since we are only interested in voters
+							proposal := NewProposal(proposalId, govtypesv1.ProposalStatus_PROPOSAL_STATUS_VOTING_PERIOD)
+							proposalsToUpdate[proposalId] = &proposal
+						}
+					}
+				}
+			}
+
+			// handle votes
+			msgVote, ok := msg.(*govtypesv1.MsgVote)
+			if ok {
+				var proposal *Proposal
+				// If proposal was already updated in the same block, use it instead of fetching from db again
+				if proposal, ok = proposalsToUpdate[msgVote.ProposalId]; !ok {
+					fetchedProposal, err := GetProposal(&db, msgVote.ProposalId)
+					if err != nil {
+						return err
+					}
+					proposal = &fetchedProposal
+					proposalsToUpdate[msgVote.ProposalId] = &fetchedProposal
+				}
+				votes := indexVotesByVoter(proposal.Votes)
+				// we can directly replace old votes with new votes since new votes will fully replace the previous vote
+				// voters cannot delete their vote, they can only change it to yes/no/abstain
+				votes[msgVote.Voter] = Vote{
+					Voter: msgVote.Voter,
+					Options: []WeightedVoteOption{
+						{
+							Weight: sdk.OneDec().String(),
+							Option: msgVote.Option.String(),
+						},
+					},
+				}
+				proposal.Votes = maps.Values(votes)
+			}
+		}
+	}
+
+	// check for proposals that are either in voting or completed
+	for _, event := range evc.ResponseEndBlock.Events {
+		fmt.Println(event.Type, event.Attributes)
+		switch event.Type {
+		case govtypes.EventTypeActiveProposal, govtypes.EventTypeInactiveProposal:
+			for _, attr := range event.Attributes {
+				switch string(attr.Key) {
+				case govtypes.AttributeKeyProposalID:
+					proposalId, err := strconv.ParseUint(string(attr.Value), 10, 64)
+					if err != nil {
+						return err
+					}
+					proposal, err := GetProposal(&db, proposalId)
+					if err != nil {
+						return err
+					}
+					result, ok := findAbciAttributeValue(event.Attributes, govtypes.AttributeKeyProposalResult)
+					if !ok {
+						panic(fmt.Errorf("wrongly formatted event, missing %s", govtypes.AttributeKeyProposalResult))
+					}
+					switch result {
+					case govtypes.AttributeValueProposalDropped:
+						proposal.Status = govtypesv1.ProposalStatus_PROPOSAL_STATUS_UNSPECIFIED
+					case govtypes.AttributeValueProposalPassed:
+						proposal.Status = govtypesv1.ProposalStatus_PROPOSAL_STATUS_PASSED
+					case govtypes.AttributeValueProposalFailed:
+						proposal.Status = govtypesv1.ProposalStatus_PROPOSAL_STATUS_FAILED
+					case govtypes.AttributeValueProposalRejected:
+						proposal.Status = govtypesv1.ProposalStatus_PROPOSAL_STATUS_REJECTED
+					}
+					proposalsToUpdate[proposalId] = &proposal
+				}
+			}
+		}
+	}
+	// update all proposals at once
+	for _, proposal := range proposalsToUpdate {
+		err = upsertProposal(db, proposal.Id, *proposal)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getProposalFromApp(height int64, app *cosmoscmd.App, proposalId uint64) (proposal govtypesv1.Proposal, err error) {
+	cms, err := (*app).CommitMultiStore().CacheMultiStoreWithVersion(height)
+	if err != nil {
+		return proposal, err
+	}
+	ctx := sdk.NewContext(cms, types.Header{
+		Height: 0,
+	}, false, logger)
+
+	tApp, ok := (*app).(*tapp.App)
+	if !ok {
+		return proposal, fmt.Errorf("invalid app expect: %T got %T", tapp.App{}, tApp)
+	}
+
+	proposal, found := tApp.GovKeeper.GetProposal(ctx, proposalId)
+	if !found {
+		return proposal, fmt.Errorf("proposal with id %d not found", proposalId)
+	}
+	return proposal, nil
+}
+
+func getVoters(height int64, app *cosmoscmd.App, proposalId uint64) (voters []Vote, err error) {
+	cms, err := (*app).CommitMultiStore().CacheMultiStoreWithVersion(height)
+	if err != nil {
+		return voters, err
+	}
+	ctx := sdk.NewContext(cms, types.Header{
+		Height: 0,
+	}, false, logger)
+
+	tApp, ok := (*app).(*tapp.App)
+	if !ok {
+		return voters, fmt.Errorf("invalid app expect: %T got %T", tapp.App{}, tApp)
+	}
+	voters = []Vote{}
+
+	tApp.GovKeeper.IterateVotes(ctx, proposalId, func(vote govtypesv1.Vote) bool {
+		voters = append(voters, Vote{
+			Voter:   vote.Voter,
+			Options: NewWeightedVoteOptions(vote.Options),
+		})
+		return false
+	})
+	return voters, err
+}
+
+func getLastIndexedHeight(db safe_batch.SafeBatchDB) (height int64, err error) {
+	bz, err := db.Get(lastIndexedHeightKey)
+	if err != nil {
+		return height, err
+	}
+	if bz == nil {
+		return 1, err
+	}
+	return int64(sdk.BigEndianToUint64(bz)), nil
+}
+
+func findAttributeValue(attrs []txindexer.EventAttribute, key string) (value string, found bool) {
+	for _, attr := range attrs {
+		if attr.Key == key {
+			return attr.Value, true
+		}
+	}
+	return value, false
+}
+
+func findAbciAttributeValue(attrs []abci.EventAttribute, key string) (value string, found bool) {
+	for _, attr := range attrs {
+		fmt.Println(string(attr.GetKey()), string(attr.GetValue()))
+		attrStr := string(attr.Key)
+		if attrStr == key {
+			return string(attr.GetValue()), true
+		}
+	}
+	return value, false
+}
+
+func upsertProposal(db safe_batch.SafeBatchDB, proposalId uint64, proposal Proposal) (err error) {
+	key := getProposalKey(proposalId)
+	b, err := tmjson.Marshal(proposal)
+	if err != nil {
+		return err
+	}
+	err = db.Set(key, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func GetProposal(db tmdb.DB, proposalId uint64) (proposal Proposal, err error) {
+	b, err := db.Get(getProposalKey(proposalId))
+	if err != nil {
+		return proposal, err
+	}
+	if b == nil {
+		return proposal, fmt.Errorf("proposal with id %d not found", proposalId)
+	}
+	err = tmjson.Unmarshal(b, &proposal)
+	if err != nil {
+		return proposal, err
+	}
+	if proposal.Votes == nil {
+		proposal.Votes = []Vote{}
+	}
+	return proposal, err
+}
+
+func IterateProposals(db safe_batch.SafeBatchDB, fromId uint64, cb func(proposal Proposal) bool) (err error) {
+	iter, err := db.Iterator(getProposalKey(fromId), sdk.PrefixEndBytes(proposalKey))
+	//iter, err := db.Iterator(getProposalKey(fromId), getProposalKey(1000))
+	if err != nil {
+		return err
+	}
+	for iter.Valid() {
+		b := iter.Value()
+		if b == nil {
+			iter.Next()
+			continue
+		}
+		var proposal Proposal
+		err = tmjson.Unmarshal(b, &proposal)
+		if err != nil {
+			return err
+		}
+		stop := cb(proposal)
+		if stop {
+			return nil
+		}
+		iter.Next()
+	}
+	return nil
+}
+
+func indexVotesByVoter(votes []Vote) (m map[string]Vote) {
+	m = make(map[string]Vote)
+	for _, vote := range votes {
+		m[vote.Voter] = vote
+	}
+	return m
+}

--- a/indexer/proposal/types.go
+++ b/indexer/proposal/types.go
@@ -1,0 +1,51 @@
+package proposal
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+)
+
+var (
+	lastIndexedHeightKey = []byte("proposal_last_height:")
+	proposalKey          = []byte("proposal:")
+)
+
+type Proposal struct {
+	Id     uint64                    `json:"id"`
+	Status govtypesv1.ProposalStatus `json:"status"`
+	Votes  []Vote                    `json:"votes"`
+}
+
+type Vote struct {
+	Voter   string               `json:"voter"`
+	Options []WeightedVoteOption `json:"options"`
+}
+
+type WeightedVoteOption struct {
+	Weight string `json:"weight""`
+	Option string `json:"option"`
+}
+
+func NewWeightedVoteOptions(options govtypesv1.WeightedVoteOptions) (wvo []WeightedVoteOption) {
+	wvo = []WeightedVoteOption{}
+	for _, option := range options {
+		wvo = append(wvo, WeightedVoteOption{
+			Weight: option.Weight,
+			Option: govtypesv1.VoteOption_name[int32(option.Option)],
+		})
+	}
+	return wvo
+}
+
+func getProposalKey(proposalId uint64) (key []byte) {
+	key = append(key, proposalKey...)
+	return append(key, sdk.Uint64ToBigEndian(proposalId)...)
+}
+
+func NewProposal(id uint64, status govtypesv1.ProposalStatus) Proposal {
+	return Proposal{
+		Id:     id,
+		Status: status,
+		Votes:  []Vote{},
+	}
+}

--- a/indexer/proposal/types.go
+++ b/indexer/proposal/types.go
@@ -6,8 +6,7 @@ import (
 )
 
 var (
-	lastIndexedHeightKey = []byte("proposal_last_height:")
-	proposalKey          = []byte("proposal:")
+	proposalKey = []byte("proposal:")
 )
 
 type Proposal struct {
@@ -24,17 +23,6 @@ type Vote struct {
 type WeightedVoteOption struct {
 	Weight string `json:"weight""`
 	Option string `json:"option"`
-}
-
-func NewWeightedVoteOptions(options govtypesv1.WeightedVoteOptions) (wvo []WeightedVoteOption) {
-	wvo = []WeightedVoteOption{}
-	for _, option := range options {
-		wvo = append(wvo, WeightedVoteOption{
-			Weight: option.Weight,
-			Option: govtypesv1.VoteOption_name[int32(option.Option)],
-		})
-	}
-	return wvo
 }
 
 func getProposalKey(proposalId uint64) (key []byte) {

--- a/indexer/tx/tx.go
+++ b/indexer/tx/tx.go
@@ -100,3 +100,15 @@ var IndexTx = indexer.CreateIndexer(func(batch safe_batch.SafeBatchDB, block *tm
 
 	return nil
 })
+
+func GetTxByHash(db safe_batch.SafeBatchDB, hash string) (txRecord TxRecord, err error) {
+	b, err := db.Get(getKey(hash))
+	if err != nil {
+		return txRecord, err
+	}
+	err = tmjson.Unmarshal(b, &txRecord)
+	if err != nil {
+		return txRecord, err
+	}
+	return txRecord, nil
+}

--- a/indexer/tx/tx.go
+++ b/indexer/tx/tx.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/ignite/cli/ignite/pkg/cosmoscmd"
+	tmdb "github.com/tendermint/tm-db"
 
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	tm "github.com/tendermint/tendermint/types"
@@ -101,7 +102,7 @@ var IndexTx = indexer.CreateIndexer(func(batch safe_batch.SafeBatchDB, block *tm
 	return nil
 })
 
-func GetTxByHash(db safe_batch.SafeBatchDB, hash string) (txRecord TxRecord, err error) {
+func GetTxByHash(db tmdb.DB, hash string) (txRecord TxRecord, err error) {
 	b, err := db.Get(getKey(hash))
 	if err != nil {
 		return txRecord, err

--- a/rpc/register.go
+++ b/rpc/register.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"

--- a/rpc/register.go
+++ b/rpc/register.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"

--- a/sync.go
+++ b/sync.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/ignite/cli/ignite/pkg/cosmoscmd"
 	"github.com/tendermint/spn/cmd"
+	"github.com/terra-money/mantlemint/indexer/proposal"
 	"io/ioutil"
 	"log"
 	"os"
@@ -154,6 +155,7 @@ func main() {
 	indexerInstance.RegisterIndexerService("tx", tx.IndexTx)
 	indexerInstance.RegisterIndexerService("block", block.IndexBlock)
 	indexerInstance.RegisterIndexerService("richlist", richlist.IndexRichlist)
+	indexerInstance.RegisterIndexerService("proposal", proposal.IndexProposals)
 
 	abcicli, _ := appCreator.NewABCIClient()
 	rpccli := rpc.NewRpcClient(abcicli)
@@ -176,6 +178,7 @@ func main() {
 			indexerInstance.RegisterRESTRoute(router, tx.RegisterRESTRoute)
 			indexerInstance.RegisterRESTRoute(router, block.RegisterRESTRoute)
 			indexerInstance.RegisterRESTRoute(router, richlist.RegisterRESTRoute)
+			indexerInstance.RegisterRESTRoute(router, proposal.RegisterRESTRoute)
 		},
 
 		// inject flag checker for synced

--- a/sync.go
+++ b/sync.go
@@ -181,6 +181,7 @@ func main() {
 			indexerInstance.RegisterRESTRoute(router, block.RegisterRESTRoute)
 			indexerInstance.RegisterRESTRoute(router, richlist.RegisterRESTRoute)
 			indexerInstance.RegisterRESTRoute(router, proposal.RegisterRESTRoute)
+			indexerInstance.RegisterRESTRoute(router, accounttx.RegisterRESTRoute)
 		},
 
 		// inject flag checker for synced

--- a/sync.go
+++ b/sync.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/ignite/cli/ignite/pkg/cosmoscmd"
 	"github.com/tendermint/spn/cmd"
+	"github.com/terra-money/mantlemint/indexer/accounttx"
 	"github.com/terra-money/mantlemint/indexer/proposal"
 	"io/ioutil"
 	"log"
@@ -156,6 +157,7 @@ func main() {
 	indexerInstance.RegisterIndexerService("block", block.IndexBlock)
 	indexerInstance.RegisterIndexerService("richlist", richlist.IndexRichlist)
 	indexerInstance.RegisterIndexerService("proposal", proposal.IndexProposals)
+	indexerInstance.RegisterIndexerService("accounttx", accounttx.IndexTx)
 
 	abcicli, _ := appCreator.NewABCIClient()
 	rpccli := rpc.NewRpcClient(abcicli)


### PR DESCRIPTION
This PR creates an indexer for 
1. Proposals 
2. Transactions indexed by related wallet (Similar to how finder displayers account history)

It exposes two new endpoints to retrieve indexed data
```
GET /index/proposal/:proposal_id
GET /index/account/:wallet_address
```