### PR TITLE
feat: proxy unhandled requests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	ChainID              string
 	RPCEndpoints         []string
 	WSEndpoints          []string
+	LCDEndpoints         []string
 	MantlemintDB         string
 	IndexerDB            string
 	DisableSync          bool
@@ -64,6 +65,12 @@ func newConfig() Config {
 		// WSEndpoints is where to pull txs from when normal syncing
 		WSEndpoints: func() []string {
 			endpoints := getValidEnv("WS_ENDPOINTS")
+			return strings.Split(endpoints, ",")
+		}(),
+
+		// LCDEndpoints is where to forward unhandled queries to a node
+		LCDEndpoints: func() []string {
+			endpoints := getValidEnv("LCD_ENDPOINTS")
 			return strings.Split(endpoints, ",")
 		}(),
 

--- a/rpc/proxy.go
+++ b/rpc/proxy.go
@@ -1,0 +1,43 @@
+package rpc
+
+import (
+	"github.com/tendermint/tendermint/libs/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+)
+
+type ProxyMiddleware struct {
+	lcdUrls []string
+	proxies []*httputil.ReverseProxy
+}
+
+func NewProxyMiddleware(lcdUrls []string) ProxyMiddleware {
+	var proxies []*httputil.ReverseProxy
+	for _, u := range lcdUrls {
+		lcdUrl, err := url.Parse(u)
+		if err != nil {
+			panic(err)
+		}
+		proxies = append(proxies, httputil.NewSingleHostReverseProxy(lcdUrl))
+	}
+	return ProxyMiddleware{
+		lcdUrls: lcdUrls,
+		proxies: proxies,
+	}
+}
+
+func (pm ProxyMiddleware) HandleRequest(writer http.ResponseWriter, request *http.Request, handler http.Handler) {
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		// randomly pick a proxy from the list
+		proxyToUse := rand.NewRand().Intn(len(pm.proxies))
+		pm.proxies[proxyToUse].ServeHTTP(writer, request)
+		return
+	}
+	writer.WriteHeader(recorder.Code)
+	writer.Write(recorder.Body.Bytes())
+	return
+}

--- a/rpc/register.go
+++ b/rpc/register.go
@@ -111,6 +111,14 @@ func StartRPC(
 		})
 	})
 
+	pm := NewProxyMiddleware(mantlemintConfig.LCDEndpoints)
+	// proxy middleware to handle unimplemented queries
+	apiSrv.Router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			pm.HandleRequest(writer, request, next)
+		})
+	})
+
 	// start api server in goroutine
 	go func() {
 		if err := apiSrv.Start(cfg); err != nil {


### PR DESCRIPTION
Allows mantlemint to proxy requests to a defined LCD for requests it cannot handle.

Adds a new env configuration `LCD_ENDPOINTS` that can be used to add a list of LCD endpoints that will be uniformly and randomly picked to serve a request that mantlemint is not able to handle.

Eg: 
<img width="731" alt="image" src="https://user-images.githubusercontent.com/3447315/208809695-d597460b-896f-4cb9-919e-f9b81e0b4242.png">
