### PR TITLE
fix: use supplyOf instead of totalSupply

### DIFF
--- a/export/export.go
+++ b/export/export.go
@@ -51,11 +51,13 @@ func ExportCirculatingSupply(app *terra.TerraApp) (sdktypes.Int, error) {
 		}
 		return false
 	})
-	totalSupply, err := app.BankKeeper.TotalSupply(sdktypes.WrapSDKContext(ctx), &banktypes.QueryTotalSupplyRequest{})
+	totalSupply, err := app.BankKeeper.SupplyOf(sdktypes.WrapSDKContext(ctx), &banktypes.QuerySupplyOfRequest{
+		Denom: "uluna",
+	})
 	if err != nil {
 		return sdktypes.Int{}, err
 	}
-	lunaTotalSupply := totalSupply.Supply.AmountOf("uluna")
+	lunaTotalSupply := totalSupply.Amount.Amount
 	communityPool, err := app.DistrKeeper.CommunityPool(sdktypes.WrapSDKContext(ctx), &distrotypes.QueryCommunityPoolRequest{})
 	if err != nil {
 		return sdktypes.Int{}, err


### PR DESCRIPTION
totalSupply endpoint is paginated and `uluna` was on the second page. Use `supplyOf` query instead.