### PR TITLE
fix: add timeout for reads to prevent halts

### DIFF
--- a/block_feed/aggregate.go
+++ b/block_feed/aggregate.go
@@ -89,7 +89,7 @@ func (ags *AggregateSubscription) Subscribe(rpcIndex int) (chan *BlockResult, er
 				}
 			}
 
-			log.Printf("[block_feed/aggregate] switching to ws...")
+			log.Printf("[block_feed/aggregate] switching to ws at height %d...", ags.lastKnownBlock)
 
 			// patch ws to aggregate
 			for {
@@ -106,6 +106,7 @@ func (ags *AggregateSubscription) Subscribe(rpcIndex int) (chan *BlockResult, er
 				} else {
 					// if block feeder got upto this point,
 					// it is relatively safe that mantle is synced
+					log.Printf("[block_feed/aggregate] received block at height %d...", r.Block.Height)
 					ags.setSyncState(true)
 					ags.aggregateBlockChannel <- r
 					ags.lastKnownBlock = r.Block.Height

--- a/block_feed/websocket.go
+++ b/block_feed/websocket.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/gorilla/websocket"
 	"log"
+	"time"
 )
 
 var _ BlockFeed = (*WSSubscription)(nil)
@@ -97,6 +98,8 @@ func handleInitialHandhake(ws *websocket.Conn) error {
 func receiveBlockEvents(ws *websocket.Conn, c chan *BlockResult) {
 	defer close(c)
 	for {
+		// There should be a block every ~6s so 20 seconds would mean the connection is faulty
+		ws.SetReadDeadline(time.Now().Add(time.Second * 20))
 		_, message, err := ws.ReadMessage()
 
 		// if read message failed,


### PR DESCRIPTION
Adding a deadline to the websocket reads to ensure that we don't wait forever on listening to a single RPC.